### PR TITLE
12 thread safe policies and metrics

### DIFF
--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -14,6 +14,7 @@ var (
 )
 
 type Policy struct {
+	ServiceID            string
 	ThresholdErrors      int
 	ResetTimeout         time.Duration
 	Errors               []error
@@ -54,8 +55,9 @@ func Reset() {
 	cbState = CircuitBreaker{}
 }
 
-func New() Policy {
+func New(serviceID string) Policy {
 	return Policy{
+		ServiceID:       serviceID,
 		ThresholdErrors: 1,
 		ResetTimeout:    time.Second * 1,
 	}
@@ -66,7 +68,7 @@ func (p Policy) Run(cmd core.Command) (*Metric, error) {
 		return nil, err
 	}
 
-	m := Metric{StartedAt: time.Now()}
+	m := Metric{ID: p.ServiceID, StartedAt: time.Now()}
 	if p.BeforeCircuitBreaker != nil {
 		p.BeforeCircuitBreaker(p, cbState)
 	}

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -1,7 +1,6 @@
 package circuitbreaker
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -62,7 +61,7 @@ func New() Policy {
 	}
 }
 
-func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
+func (p Policy) Run(cmd core.Command) (*Metric, error) {
 	if err := p.validate(); err != nil {
 		return nil, err
 	}
@@ -82,7 +81,7 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 		return &m, ErrCircuitIsOpen
 	}
 
-	err := cmd(ctx)
+	err := cmd()
 	m.Error = err
 
 	setPostState(p, err)

--- a/core/core.go
+++ b/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 type Command func(ctx context.Context) error
@@ -11,6 +12,12 @@ type PolicySupplier interface {
 	Run(ctx context.Context, cmd Command) error
 	handledError(err error) bool
 	validate() error
+}
+
+type MetricRecorder interface {
+	ServiceID() string
+	PolicyDuration() time.Duration
+	Success() bool
 }
 
 func ErrorInErrors(expectedErrors []error, err error) bool {

--- a/core/core.go
+++ b/core/core.go
@@ -6,10 +6,10 @@ import (
 	"time"
 )
 
-type Command func(ctx context.Context) error
+type Command func() error
 
 type PolicySupplier interface {
-	Run(ctx context.Context, cmd Command) error
+	Run(ctx context.Context, cmd Command) (MetricRecorder, error)
 	handledError(err error) bool
 	validate() error
 }

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -13,6 +13,7 @@ var (
 )
 
 type Policy struct {
+	ServiceID       string
 	Errors          []error
 	FallBackHandler func(err error)
 	BeforeFallBack  func(p Policy)
@@ -27,8 +28,8 @@ type Metric struct {
 	Error      error
 }
 
-func New() Policy {
-	return Policy{}
+func New(serviceID string) Policy {
+	return Policy{ServiceID: serviceID}
 }
 
 func (p Policy) Run(cmd core.Command) (*Metric, error) {
@@ -36,7 +37,7 @@ func (p Policy) Run(cmd core.Command) (*Metric, error) {
 		return nil, err
 	}
 
-	m := Metric{StartedAt: time.Now()}
+	m := Metric{ID: p.ServiceID, StartedAt: time.Now()}
 	if p.BeforeFallBack != nil {
 		p.BeforeFallBack(p)
 	}

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -1,7 +1,6 @@
 package fallback
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -32,7 +31,7 @@ func New() Policy {
 	return Policy{}
 }
 
-func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
+func (p Policy) Run(cmd core.Command) (*Metric, error) {
 	if err := p.validate(); err != nil {
 		return nil, err
 	}
@@ -42,7 +41,7 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 		p.BeforeFallBack(p)
 	}
 
-	err := cmd(ctx)
+	err := cmd()
 	m.Error = err
 
 	if p.AfterFallBack != nil {

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -3,6 +3,7 @@ package fallback
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/aureliano/resiliencia/core"
 )
@@ -13,40 +14,52 @@ var (
 )
 
 type Policy struct {
-	Errors           []error
-	FallBackHandler  func(err error)
-	BeforeFallBack   func(p Policy)
-	AfterTryFallBack func(p Policy, err error)
+	Errors          []error
+	FallBackHandler func(err error)
+	BeforeFallBack  func(p Policy)
+	AfterFallBack   func(p Policy, err error)
+}
+
+type Metric struct {
+	ID         string
+	Status     int
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Error      error
 }
 
 func New() Policy {
 	return Policy{}
 }
 
-func (p Policy) Run(ctx context.Context, cmd core.Command) error {
+func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 	if err := p.validate(); err != nil {
-		return err
+		return nil, err
 	}
 
+	m := Metric{StartedAt: time.Now()}
 	if p.BeforeFallBack != nil {
 		p.BeforeFallBack(p)
 	}
 
 	err := cmd(ctx)
+	m.Error = err
 
-	if p.AfterTryFallBack != nil {
-		p.AfterTryFallBack(p, err)
+	if p.AfterFallBack != nil {
+		p.AfterFallBack(p, err)
 	}
+	m.FinishedAt = time.Now()
 
 	if err != nil && !p.handledError(err) {
-		return ErrUnhandledError
+		m.Status = 1
+		return &m, ErrUnhandledError
 	}
 
 	if err != nil {
 		p.FallBackHandler(err)
 	}
 
-	return nil
+	return &m, nil
 }
 
 func (p Policy) handledError(err error) bool {
@@ -59,4 +72,16 @@ func (p Policy) validate() error {
 	}
 
 	return nil
+}
+
+func (m *Metric) ServiceID() string {
+	return m.ID
+}
+
+func (m *Metric) PolicyDuration() time.Duration {
+	return m.FinishedAt.Sub(m.StartedAt)
+}
+
+func (m *Metric) Success() bool {
+	return m.Status == 0
 }

--- a/fallback/fallback_test.go
+++ b/fallback/fallback_test.go
@@ -9,8 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNew(t *testing.T) {
+	p := fallback.New("service-id")
+	assert.Equal(t, "service-id", p.ServiceID)
+}
+
 func TestRunValidatePolicyFallBackHandler(t *testing.T) {
-	p := fallback.New()
+	p := fallback.New("service-id")
 	_, err := p.Run(func() error { return nil })
 
 	assert.ErrorIs(t, err, fallback.ErrNoFallBackHandler)
@@ -18,7 +23,7 @@ func TestRunValidatePolicyFallBackHandler(t *testing.T) {
 
 func TestRunNoFallback(t *testing.T) {
 	fallbackCalled := false
-	p := fallback.New()
+	p := fallback.New("service-id")
 	p.FallBackHandler = func(err error) {
 		fallbackCalled = true
 	}
@@ -28,11 +33,11 @@ func TestRunNoFallback(t *testing.T) {
 
 	assert.False(t, fallbackCalled)
 
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "service-id", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
 	assert.Nil(t, m.Error)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "service-id", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 }
@@ -42,7 +47,7 @@ func TestRunHandleError(t *testing.T) {
 	errTest1 := errors.New("error test 1")
 	errTest2 := errors.New("error test 2")
 
-	p := fallback.New()
+	p := fallback.New("service-id")
 	p.Errors = []error{errTest1, errTest2}
 	p.FallBackHandler = func(err error) {
 		fallbackCalled = true
@@ -54,11 +59,11 @@ func TestRunHandleError(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, fallbackCalled)
 
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "service-id", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
 	assert.ErrorIs(t, m.Error, errTest2)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "service-id", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 }
@@ -69,7 +74,7 @@ func TestRunUnhandledError(t *testing.T) {
 	errTest2 := errors.New("error test 2")
 	errTest3 := errors.New("error test 3")
 
-	p := fallback.New()
+	p := fallback.New("service-id")
 	p.Errors = []error{errTest1, errTest2}
 	p.FallBackHandler = func(err error) {
 		fallbackCalled = true
@@ -81,11 +86,11 @@ func TestRunUnhandledError(t *testing.T) {
 	assert.ErrorIs(t, fallback.ErrUnhandledError, err)
 	assert.False(t, fallbackCalled)
 
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "service-id", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
 	assert.ErrorIs(t, m.Error, errTest3)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "service-id", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
 }

--- a/fallback/fallback_test.go
+++ b/fallback/fallback_test.go
@@ -3,8 +3,8 @@ package fallback_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aureliano/resiliencia/fallback"
 	"github.com/stretchr/testify/assert"
@@ -12,9 +12,9 @@ import (
 
 func TestRunValidatePolicyFallBackHandler(t *testing.T) {
 	p := fallback.New()
-	err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
 
-	assert.ErrorIs(t, fallback.ErrNoFallBackHandler, err)
+	assert.ErrorIs(t, err, fallback.ErrNoFallBackHandler)
 }
 
 func TestRunNoFallback(t *testing.T) {
@@ -24,10 +24,18 @@ func TestRunNoFallback(t *testing.T) {
 		fallbackCalled = true
 	}
 	p.BeforeFallBack = func(p fallback.Policy) {}
-	p.AfterTryFallBack = func(p fallback.Policy, err error) {}
-	_ = p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	p.AfterFallBack = func(p fallback.Policy, err error) {}
+	m, _ := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
 
 	assert.False(t, fallbackCalled)
+
+	assert.Equal(t, "", m.ID)
+	assert.Equal(t, 0, m.Status)
+	assert.Less(t, m.StartedAt, m.FinishedAt)
+	assert.Nil(t, m.Error)
+	assert.Equal(t, "", m.ServiceID())
+	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
+	assert.True(t, m.Success())
 }
 
 func TestRunHandleError(t *testing.T) {
@@ -41,17 +49,26 @@ func TestRunHandleError(t *testing.T) {
 		fallbackCalled = true
 	}
 	p.BeforeFallBack = func(p fallback.Policy) {}
-	p.AfterTryFallBack = func(p fallback.Policy, err error) {}
-	err := p.Run(context.TODO(), func(ctx context.Context) error { return errTest2 })
+	p.AfterFallBack = func(p fallback.Policy, err error) {}
+	m, err := p.Run(context.TODO(), func(ctx context.Context) error { return errTest2 })
 
 	assert.Nil(t, err)
 	assert.True(t, fallbackCalled)
+
+	assert.Equal(t, "", m.ID)
+	assert.Equal(t, 0, m.Status)
+	assert.Less(t, m.StartedAt, m.FinishedAt)
+	assert.ErrorIs(t, m.Error, errTest2)
+	assert.Equal(t, "", m.ServiceID())
+	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
+	assert.True(t, m.Success())
 }
 
-func TestRunUnhandleError(t *testing.T) {
+func TestRunUnhandledError(t *testing.T) {
 	fallbackCalled := false
 	errTest1 := errors.New("error test 1")
 	errTest2 := errors.New("error test 2")
+	errTest3 := errors.New("error test 3")
 
 	p := fallback.New()
 	p.Errors = []error{errTest1, errTest2}
@@ -59,9 +76,17 @@ func TestRunUnhandleError(t *testing.T) {
 		fallbackCalled = true
 	}
 	p.BeforeFallBack = func(p fallback.Policy) {}
-	p.AfterTryFallBack = func(p fallback.Policy, err error) {}
-	err := p.Run(context.TODO(), func(ctx context.Context) error { return fmt.Errorf("unknown error") })
+	p.AfterFallBack = func(p fallback.Policy, err error) {}
+	m, err := p.Run(context.TODO(), func(ctx context.Context) error { return errTest3 })
 
 	assert.ErrorIs(t, fallback.ErrUnhandledError, err)
 	assert.False(t, fallbackCalled)
+
+	assert.Equal(t, "", m.ID)
+	assert.Equal(t, 1, m.Status)
+	assert.Less(t, m.StartedAt, m.FinishedAt)
+	assert.ErrorIs(t, m.Error, errTest3)
+	assert.Equal(t, "", m.ServiceID())
+	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
+	assert.False(t, m.Success())
 }

--- a/fallback/fallback_test.go
+++ b/fallback/fallback_test.go
@@ -1,7 +1,6 @@
 package fallback_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -12,7 +11,7 @@ import (
 
 func TestRunValidatePolicyFallBackHandler(t *testing.T) {
 	p := fallback.New()
-	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	_, err := p.Run(func() error { return nil })
 
 	assert.ErrorIs(t, err, fallback.ErrNoFallBackHandler)
 }
@@ -25,7 +24,7 @@ func TestRunNoFallback(t *testing.T) {
 	}
 	p.BeforeFallBack = func(p fallback.Policy) {}
 	p.AfterFallBack = func(p fallback.Policy, err error) {}
-	m, _ := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	m, _ := p.Run(func() error { return nil })
 
 	assert.False(t, fallbackCalled)
 
@@ -50,7 +49,7 @@ func TestRunHandleError(t *testing.T) {
 	}
 	p.BeforeFallBack = func(p fallback.Policy) {}
 	p.AfterFallBack = func(p fallback.Policy, err error) {}
-	m, err := p.Run(context.TODO(), func(ctx context.Context) error { return errTest2 })
+	m, err := p.Run(func() error { return errTest2 })
 
 	assert.Nil(t, err)
 	assert.True(t, fallbackCalled)
@@ -77,7 +76,7 @@ func TestRunUnhandledError(t *testing.T) {
 	}
 	p.BeforeFallBack = func(p fallback.Policy) {}
 	p.AfterFallBack = func(p fallback.Policy, err error) {}
-	m, err := p.Run(context.TODO(), func(ctx context.Context) error { return errTest3 })
+	m, err := p.Run(func() error { return errTest3 })
 
 	assert.ErrorIs(t, fallback.ErrUnhandledError, err)
 	assert.False(t, fallbackCalled)

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -15,6 +15,7 @@ var (
 )
 
 type Policy struct {
+	ServiceID string
 	Tries     int
 	Delay     time.Duration
 	Errors    []error
@@ -37,10 +38,11 @@ type Metric struct {
 	}
 }
 
-func New() Policy {
+func New(serviceID string) Policy {
 	return Policy{
-		Tries: 1,
-		Delay: 0,
+		ServiceID: serviceID,
+		Tries:     1,
+		Delay:     0,
 	}
 }
 
@@ -49,7 +51,7 @@ func (p Policy) Run(cmd core.Command) (*Metric, error) {
 		return nil, err
 	}
 
-	m := Metric{StartedAt: time.Now(), Executions: make([]struct {
+	m := Metric{ID: p.ServiceID, StartedAt: time.Now(), Executions: make([]struct {
 		Iteration  int
 		StartedAt  time.Time
 		FinishedAt time.Time

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,7 +1,6 @@
 package retry
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -45,7 +44,7 @@ func New() Policy {
 	}
 }
 
-func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
+func (p Policy) Run(cmd core.Command) (*Metric, error) {
 	if err := p.validate(); err != nil {
 		return nil, err
 	}
@@ -69,7 +68,7 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 		}
 
 		m.Executions[i].StartedAt = time.Now()
-		err := cmd(ctx)
+		err := cmd()
 		m.Executions[i].Error = err
 		m.Executions[i].FinishedAt = time.Now()
 		m.FinishedAt = time.Now()

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -23,6 +23,20 @@ type Policy struct {
 	AfterTry  func(p Policy, try int, err error)
 }
 
+type Metric struct {
+	ID         string
+	Tries      int
+	Status     int
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Executions []struct {
+		Iteration  int
+		StartedAt  time.Time
+		FinishedAt time.Time
+		Duration   time.Duration
+	}
+}
+
 func New() Policy {
 	return Policy{
 		Tries: 1,
@@ -30,26 +44,41 @@ func New() Policy {
 	}
 }
 
-func (p Policy) Run(ctx context.Context, cmd core.Command) error {
-	done := false
+func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 	if err := p.validate(); err != nil {
-		return err
+		return nil, err
 	}
+
+	m := Metric{StartedAt: time.Now(), Executions: make([]struct {
+		Iteration  int
+		StartedAt  time.Time
+		FinishedAt time.Time
+		Duration   time.Duration
+	}, p.Tries)}
+	done := false
 
 	for i := 0; i < p.Tries; i++ {
 		turn := i + 1
+		m.Tries = turn
+		m.Executions[i].Iteration = turn
+
 		if p.BeforeTry != nil {
 			p.BeforeTry(p, turn)
 		}
 
+		m.Executions[i].StartedAt = time.Now()
 		err := cmd(ctx)
+		m.Executions[i].FinishedAt = time.Now()
+		m.FinishedAt = time.Now()
+		m.Executions[i].Duration = m.Executions[i].FinishedAt.Sub(m.Executions[i].StartedAt)
 
 		if p.AfterTry != nil {
 			p.AfterTry(p, turn, err)
 		}
 
 		if err != nil && !p.handledError(err) {
-			return ErrUnhandledError
+			m.Status = 1
+			return &m, ErrUnhandledError
 		}
 
 		if err == nil {
@@ -60,11 +89,13 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) error {
 		time.Sleep(p.Delay)
 	}
 
+	m.FinishedAt = time.Now()
 	if !done {
-		return ErrExceededTries
+		m.Status = 1
+		return &m, ErrExceededTries
 	}
 
-	return nil
+	return &m, nil
 }
 
 func (p Policy) handledError(err error) bool {
@@ -80,4 +111,21 @@ func (p Policy) validate() error {
 	default:
 		return nil
 	}
+}
+
+func (m *Metric) ServiceID() string {
+	return m.ID
+}
+
+func (m *Metric) PolicyDuration() time.Duration {
+	sum := time.Duration(0)
+	for _, exec := range m.Executions {
+		sum += exec.Duration
+	}
+
+	return sum
+}
+
+func (m *Metric) Success() bool {
+	return m.Status == 0
 }

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -34,6 +34,7 @@ type Metric struct {
 		StartedAt  time.Time
 		FinishedAt time.Time
 		Duration   time.Duration
+		Error      error
 	}
 }
 
@@ -54,6 +55,7 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 		StartedAt  time.Time
 		FinishedAt time.Time
 		Duration   time.Duration
+		Error      error
 	}, p.Tries)}
 	done := false
 
@@ -68,6 +70,7 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 
 		m.Executions[i].StartedAt = time.Now()
 		err := cmd(ctx)
+		m.Executions[i].Error = err
 		m.Executions[i].FinishedAt = time.Now()
 		m.FinishedAt = time.Now()
 		m.Executions[i].Duration = m.Executions[i].FinishedAt.Sub(m.Executions[i].StartedAt)

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,7 +1,6 @@
 package retry_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -18,14 +17,14 @@ func TestNew(t *testing.T) {
 
 func TestRunValidatePolicyTries(t *testing.T) {
 	p := retry.Policy{Tries: 0, Delay: time.Duration(100)}
-	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	_, err := p.Run(func() error { return nil })
 
 	assert.ErrorIs(t, err, retry.ErrTriesError)
 }
 
 func TestRunValidatePolicyDelay(t *testing.T) {
 	p := retry.Policy{Tries: 10, Delay: time.Duration(-1)}
-	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	_, err := p.Run(func() error { return nil })
 
 	assert.ErrorIs(t, err, retry.ErrDelayError)
 }
@@ -45,10 +44,7 @@ func TestRunMaxTriesExceeded(t *testing.T) {
 		timesAfter++
 	}
 
-	ctx := context.TODO()
-	m, e := p.Run(ctx, func(ctx context.Context) error {
-		return errTest
-	})
+	m, e := p.Run(func() error { return errTest })
 
 	assert.Equal(t, p.Tries, timesBefore)
 	assert.Equal(t, p.Tries, timesAfter)
@@ -83,9 +79,8 @@ func TestRunHandledErrors(t *testing.T) {
 		timesAfter++
 	}
 
-	ctx := context.TODO()
 	counter := 0
-	m, e := p.Run(ctx, func(ctx context.Context) error {
+	m, e := p.Run(func() error {
 		counter++
 		switch {
 		case counter == 1:
@@ -131,9 +126,8 @@ func TestRunUnhandledError(t *testing.T) {
 		timesAfter++
 	}
 
-	ctx := context.TODO()
 	counter := 0
-	m, e := p.Run(ctx, func(ctx context.Context) error {
+	m, e := p.Run(func() error {
 		counter++
 		switch {
 		case counter == 1:
@@ -177,10 +171,7 @@ func TestRun(t *testing.T) {
 		timesAfter++
 	}
 
-	ctx := context.TODO()
-	m, e := p.Run(ctx, func(ctx context.Context) error {
-		return nil
-	})
+	m, e := p.Run(func() error { return nil })
 
 	assert.Equal(t, 1, timesBefore)
 	assert.Equal(t, 1, timesAfter)

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	p := retry.New()
+	p := retry.New("postForm")
+	assert.Equal(t, "postForm", p.ServiceID)
 	assert.Equal(t, 1, p.Tries)
 	assert.Equal(t, time.Duration(0), p.Delay)
 }
@@ -33,7 +34,7 @@ func TestRunMaxTriesExceeded(t *testing.T) {
 	timesAfter, timesBefore := 0, 0
 	errTest := errors.New("any")
 
-	p := retry.New()
+	p := retry.New("postForm")
 	p.Tries = 3
 	p.Errors = []error{errTest}
 	p.Delay = time.Millisecond * 10
@@ -52,9 +53,9 @@ func TestRunMaxTriesExceeded(t *testing.T) {
 
 	assert.Equal(t, p.Tries, m.Tries)
 	assert.Equal(t, 1, m.Status)
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "postForm", m.ID)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
 
@@ -68,7 +69,7 @@ func TestRunHandledErrors(t *testing.T) {
 	errTest2 := errors.New("error test 2")
 	timesAfter, timesBefore := 0, 0
 
-	p := retry.New()
+	p := retry.New("postForm")
 	p.Tries = 3
 	p.Delay = time.Millisecond * 10
 	p.Errors = []error{errTest1, errTest2}
@@ -98,9 +99,9 @@ func TestRunHandledErrors(t *testing.T) {
 
 	assert.Equal(t, p.Tries, m.Tries)
 	assert.Equal(t, 0, m.Status)
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "postForm", m.ID)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 
@@ -115,7 +116,7 @@ func TestRunUnhandledError(t *testing.T) {
 	errTest3 := errors.New("error test 3")
 	timesAfter, timesBefore := 0, 0
 
-	p := retry.New()
+	p := retry.New("postForm")
 	p.Tries = 5
 	p.Delay = time.Millisecond * 10
 	p.Errors = []error{errTest1, errTest2}
@@ -147,9 +148,9 @@ func TestRunUnhandledError(t *testing.T) {
 
 	assert.Equal(t, 3, m.Tries)
 	assert.Equal(t, 1, m.Status)
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "postForm", m.ID)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
 
@@ -161,7 +162,7 @@ func TestRunUnhandledError(t *testing.T) {
 func TestRun(t *testing.T) {
 	timesAfter, timesBefore := 0, 0
 
-	p := retry.New()
+	p := retry.New("postForm")
 	p.Tries = 3
 	p.Delay = time.Millisecond * 10
 	p.BeforeTry = func(p retry.Policy, try int) {
@@ -179,9 +180,9 @@ func TestRun(t *testing.T) {
 
 	assert.Equal(t, 1, m.Tries)
 	assert.Equal(t, 0, m.Status)
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "postForm", m.ID)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -20,14 +20,14 @@ func TestRunValidatePolicyTries(t *testing.T) {
 	p := retry.Policy{Tries: 0, Delay: time.Duration(100)}
 	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
 
-	assert.ErrorIs(t, retry.ErrTriesError, err)
+	assert.ErrorIs(t, err, retry.ErrTriesError)
 }
 
 func TestRunValidatePolicyDelay(t *testing.T) {
 	p := retry.Policy{Tries: 10, Delay: time.Duration(-1)}
 	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
 
-	assert.ErrorIs(t, retry.ErrDelayError, err)
+	assert.ErrorIs(t, err, retry.ErrDelayError)
 }
 
 func TestRunMaxTriesExceeded(t *testing.T) {
@@ -63,7 +63,7 @@ func TestRunMaxTriesExceeded(t *testing.T) {
 	assert.False(t, m.Success())
 
 	for _, exec := range m.Executions {
-		assert.ErrorIs(t, exec.Error, errTest)
+		assert.ErrorIs(t, errTest, exec.Error)
 	}
 }
 
@@ -109,8 +109,8 @@ func TestRunHandledErrors(t *testing.T) {
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 
-	assert.ErrorIs(t, m.Executions[0].Error, errTest1)
-	assert.ErrorIs(t, m.Executions[1].Error, errTest2)
+	assert.ErrorIs(t, errTest1, m.Executions[0].Error)
+	assert.ErrorIs(t, errTest2, m.Executions[1].Error)
 	assert.Nil(t, m.Executions[2].Error)
 }
 
@@ -149,7 +149,7 @@ func TestRunUnhandledError(t *testing.T) {
 
 	assert.Equal(t, 3, timesBefore)
 	assert.Equal(t, 3, timesAfter)
-	assert.ErrorIs(t, retry.ErrUnhandledError, e)
+	assert.ErrorIs(t, e, retry.ErrUnhandledError)
 
 	assert.Equal(t, 3, m.Tries)
 	assert.Equal(t, 1, m.Status)
@@ -159,9 +159,9 @@ func TestRunUnhandledError(t *testing.T) {
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
 
-	assert.ErrorIs(t, m.Executions[0].Error, errTest1)
-	assert.ErrorIs(t, m.Executions[1].Error, errTest2)
-	assert.ErrorIs(t, m.Executions[2].Error, errTest3)
+	assert.ErrorIs(t, errTest1, m.Executions[0].Error)
+	assert.ErrorIs(t, errTest2, m.Executions[1].Error)
+	assert.ErrorIs(t, errTest3, m.Executions[2].Error)
 }
 
 func TestRun(t *testing.T) {

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -12,6 +12,7 @@ var (
 )
 
 type Policy struct {
+	ServiceID     string
 	Timeout       time.Duration
 	BeforeTimeout func(p Policy)
 	AfterTimeout  func(p Policy, err error)
@@ -25,9 +26,10 @@ type Metric struct {
 	Error      error
 }
 
-func New() Policy {
+func New(serviceID string) Policy {
 	return Policy{
-		Timeout: 0,
+		ServiceID: serviceID,
+		Timeout:   0,
 	}
 }
 
@@ -36,7 +38,7 @@ func (p Policy) Run(cmd core.Command) (*Metric, error) {
 		return nil, err
 	}
 
-	m := Metric{StartedAt: time.Now()}
+	m := Metric{ID: p.ServiceID, StartedAt: time.Now()}
 	if p.BeforeTimeout != nil {
 		p.BeforeTimeout(p)
 	}

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -1,7 +1,6 @@
 package timeout
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -32,7 +31,7 @@ func New() Policy {
 	}
 }
 
-func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
+func (p Policy) Run(cmd core.Command) (*Metric, error) {
 	if err := p.validate(); err != nil {
 		return nil, err
 	}
@@ -46,7 +45,7 @@ func (p Policy) Run(ctx context.Context, cmd core.Command) (*Metric, error) {
 	c := make(chan string)
 	go func() {
 		c <- "start"
-		cmdErr = cmd(ctx)
+		cmdErr = cmd()
 		m.Error = cmdErr
 		c <- "done"
 	}()

--- a/timeout/timeout_test.go
+++ b/timeout/timeout_test.go
@@ -1,7 +1,6 @@
 package timeout_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -18,7 +17,7 @@ func TestNew(t *testing.T) {
 func TestRunValidatePolicyTimeout(t *testing.T) {
 	p := timeout.New()
 	p.Timeout = -1
-	_, err := p.Run(context.TODO(), func(ctx context.Context) error { return nil })
+	_, err := p.Run(func() error { return nil })
 
 	assert.ErrorIs(t, timeout.ErrTimeoutError, err)
 }
@@ -28,9 +27,7 @@ func TestRun(t *testing.T) {
 	p.Timeout = time.Second * 4
 	p.BeforeTimeout = func(p timeout.Policy) {}
 	p.AfterTimeout = func(p timeout.Policy, err error) {}
-	m, err := p.Run(context.TODO(), func(ctx context.Context) error {
-		return nil
-	})
+	m, err := p.Run(func() error { return nil })
 
 	assert.Nil(t, err)
 
@@ -49,9 +46,7 @@ func TestRunWithUnknownError(t *testing.T) {
 	p.Timeout = time.Second * 4
 	p.BeforeTimeout = func(p timeout.Policy) {}
 	p.AfterTimeout = func(p timeout.Policy, err error) {}
-	m, err := p.Run(context.TODO(), func(ctx context.Context) error {
-		return errTest
-	})
+	m, err := p.Run(func() error { return errTest })
 
 	assert.Nil(t, err)
 
@@ -69,7 +64,7 @@ func TestRunTimeout(t *testing.T) {
 	p.Timeout = time.Millisecond * 500
 	p.BeforeTimeout = func(p timeout.Policy) {}
 	p.AfterTimeout = func(p timeout.Policy, err error) {}
-	m, err := p.Run(context.TODO(), func(ctx context.Context) error {
+	m, err := p.Run(func() error {
 		time.Sleep(time.Millisecond * 550)
 		return nil
 	})

--- a/timeout/timeout_test.go
+++ b/timeout/timeout_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	p := timeout.New()
+	p := timeout.New("remote-service")
+	assert.Equal(t, "remote-service", p.ServiceID)
 	assert.Equal(t, time.Duration(0), p.Timeout)
 }
 
 func TestRunValidatePolicyTimeout(t *testing.T) {
-	p := timeout.New()
+	p := timeout.New("remote-service")
 	p.Timeout = -1
 	_, err := p.Run(func() error { return nil })
 
@@ -23,7 +24,7 @@ func TestRunValidatePolicyTimeout(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	p := timeout.New()
+	p := timeout.New("remote-service")
 	p.Timeout = time.Second * 4
 	p.BeforeTimeout = func(p timeout.Policy) {}
 	p.AfterTimeout = func(p timeout.Policy, err error) {}
@@ -31,18 +32,18 @@ func TestRun(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "remote-service", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
 	assert.Nil(t, m.Error)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "remote-service", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 }
 
 func TestRunWithUnknownError(t *testing.T) {
 	errTest := errors.New("err test")
-	p := timeout.New()
+	p := timeout.New("remote-service")
 	p.Timeout = time.Second * 4
 	p.BeforeTimeout = func(p timeout.Policy) {}
 	p.AfterTimeout = func(p timeout.Policy, err error) {}
@@ -50,17 +51,17 @@ func TestRunWithUnknownError(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "remote-service", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
 	assert.ErrorIs(t, m.Error, errTest)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "remote-service", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
 }
 
 func TestRunTimeout(t *testing.T) {
-	p := timeout.New()
+	p := timeout.New("remote-service")
 	p.Timeout = time.Millisecond * 500
 	p.BeforeTimeout = func(p timeout.Policy) {}
 	p.AfterTimeout = func(p timeout.Policy, err error) {}
@@ -71,11 +72,11 @@ func TestRunTimeout(t *testing.T) {
 
 	assert.ErrorIs(t, timeout.ErrTimeoutError, err)
 
-	assert.Equal(t, "", m.ID)
+	assert.Equal(t, "remote-service", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
 	assert.Nil(t, m.Error)
-	assert.Equal(t, "", m.ServiceID())
+	assert.Equal(t, "remote-service", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
 }


### PR DESCRIPTION
Makes circuit breaker policy thread-safe. It wasn't necessary to do anything on the others because just circuit breaker needs a cache in order to save state. Closes #12.