### PR TITLE
24 fallback handler not called

### DIFF
--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -188,6 +188,7 @@ func (p Policy) Run(metric core.Metric) error {
 	}
 
 	err := execute(p, metric)
+	err = pickError(err, metric)
 
 	if err != nil {
 		m.Error = err
@@ -294,6 +295,14 @@ func validate(p Policy) error {
 
 func newCache() *circuitBreakerCache {
 	return &circuitBreakerCache{cache: make(map[string]*CircuitBreaker)}
+}
+
+func pickError(err error, metric core.MetricRecorder) error {
+	if err != nil {
+		return err
+	}
+
+	return metric.MetricError()
 }
 
 // ServiceID returns the service id registered to the policy binded to this metric.

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -312,3 +312,8 @@ func (m Metric) PolicyDuration() time.Duration {
 func (m Metric) Success() bool {
 	return (m.Status == 0) && (m.Error == nil)
 }
+
+// MetricError returns the error that a command supplier or a wrapped policy raised.
+func (m Metric) MetricError() error {
+	return m.Error
+}

--- a/circuitbreaker/circuitbreaker_test.go
+++ b/circuitbreaker/circuitbreaker_test.go
@@ -50,6 +50,10 @@ func (m Metric) Success() bool {
 	return m.Status == 0
 }
 
+func (m Metric) MetricError() error {
+	return m.Error
+}
+
 func TestPolicyImplementsPolicySupplier(t *testing.T) {
 	p := circuitbreaker.New("service-name")
 	i := reflect.TypeOf((*core.PolicySupplier)(nil)).Elem()
@@ -170,7 +174,7 @@ func TestRunCommandCircuitIsOpen(t *testing.T) {
 	assert.Equal(t, "backend-service-name-1", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest)
+	assert.ErrorIs(t, m.MetricError(), errTest)
 	assert.EqualValues(t, circuitbreaker.OpenState, m.State)
 	assert.Equal(t, 1, m.ErrorCount)
 	assert.Equal(t, "backend-service-name-1", m.ServiceID())
@@ -186,7 +190,7 @@ func TestRunCommandCircuitIsOpen(t *testing.T) {
 
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, circuitbreaker.ErrCircuitIsOpen)
+	assert.ErrorIs(t, m.MetricError(), circuitbreaker.ErrCircuitIsOpen)
 	assert.EqualValues(t, circuitbreaker.OpenState, m.State)
 	assert.Equal(t, 1, m.ErrorCount)
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
@@ -221,7 +225,7 @@ func TestRunCommandCircuitHalfOpenSetToClosed(t *testing.T) {
 	assert.Equal(t, "backend-service-name-2", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest)
+	assert.ErrorIs(t, m.MetricError(), errTest)
 	assert.Equal(t, "backend-service-name-2", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
@@ -239,7 +243,7 @@ func TestRunCommandCircuitHalfOpenSetToClosed(t *testing.T) {
 	assert.Equal(t, "backend-service-name-2", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, circuitbreaker.ErrCircuitIsOpen)
+	assert.ErrorIs(t, m.MetricError(), circuitbreaker.ErrCircuitIsOpen)
 	assert.Equal(t, "backend-service-name-2", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
@@ -262,7 +266,7 @@ func TestRunCommandCircuitHalfOpenSetToClosed(t *testing.T) {
 	assert.Equal(t, "backend-service-name-2", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Nil(t, m.Error)
+	assert.Nil(t, m.MetricError())
 	assert.Equal(t, "backend-service-name-2", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
@@ -346,7 +350,7 @@ func TestRunCommandHandledErrors(t *testing.T) {
 	assert.Equal(t, "backend-service-name-3", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest1)
+	assert.ErrorIs(t, m.MetricError(), errTest1)
 	assert.Equal(t, "backend-service-name-3", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
@@ -362,7 +366,7 @@ func TestRunCommandHandledErrors(t *testing.T) {
 	assert.Equal(t, "backend-service-name-3", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest2)
+	assert.ErrorIs(t, m.MetricError(), errTest2)
 	assert.Equal(t, "backend-service-name-3", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
@@ -395,7 +399,7 @@ func TestRunCommandUnhandledError(t *testing.T) {
 	assert.Equal(t, "backend-service-name-4", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest1)
+	assert.ErrorIs(t, m.MetricError(), errTest1)
 	assert.Equal(t, "backend-service-name-4", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
@@ -411,7 +415,7 @@ func TestRunCommandUnhandledError(t *testing.T) {
 	assert.Equal(t, "backend-service-name-4", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest2)
+	assert.ErrorIs(t, m.MetricError(), errTest2)
 	assert.Equal(t, "backend-service-name-4", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())

--- a/core/core.go
+++ b/core/core.go
@@ -97,7 +97,9 @@ func (m Metric) MetricError() error {
 //
 // Return: whether err is in expectedErrors.
 func ErrorInErrors(expectedErrors []error, err error) bool {
-	if len(expectedErrors) == 0 {
+	if err == nil {
+		return true
+	} else if len(expectedErrors) == 0 {
 		return false
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -33,6 +33,8 @@ type MetricRecorder interface {
 
 	// Success returns whether the policy execution succeeded or not.
 	Success() bool
+
+	MetricError() error
 }
 
 // Metric is the base metric recorder type. This is the one which is passed through the life
@@ -76,6 +78,19 @@ func (m Metric) Success() bool {
 	}
 
 	return true
+}
+
+// MetricError returns the first error occurred in the policy chain.
+//
+// Return: the first found error.
+func (m Metric) MetricError() error {
+	for _, v := range m {
+		if !v.Success() {
+			return v.MetricError()
+		}
+	}
+
+	return nil
 }
 
 // ErrorInErrors Verifies that an error is a slice of expected errors.

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -96,6 +96,8 @@ func TestErrorInErrors(t *testing.T) {
 	for i := 0; i < total; i++ {
 		assert.True(t, core.ErrorInErrors(errs, errs[i]))
 	}
+
+	assert.True(t, core.ErrorInErrors(errs, nil))
 }
 
 func TestErrorInErrorsNotFound(t *testing.T) {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -26,6 +26,14 @@ func (m dummyMetric) Success() bool {
 	return m.status == 0
 }
 
+func (m dummyMetric) MetricError() error {
+	if m.status == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("any error")
+}
+
 func TestMetricImplementsMetricRecorder(t *testing.T) {
 	m := core.Metric{}
 	i := reflect.TypeOf((*core.MetricRecorder)(nil)).Elem()
@@ -60,6 +68,17 @@ func TestSuccess(t *testing.T) {
 	m["test2"] = dummyMetric{status: 1}
 
 	assert.False(t, m.Success())
+}
+
+func TestMetricError(t *testing.T) {
+	m := core.NewMetric()
+	m["test"] = dummyMetric{}
+
+	assert.Nil(t, m.MetricError())
+
+	m["test2"] = dummyMetric{status: 1}
+
+	assert.Equal(t, "any error", m.MetricError().Error())
 }
 
 func TestErrorInErrorsEmpty(t *testing.T) {

--- a/example/circuitbreaker/policy/main.go
+++ b/example/circuitbreaker/policy/main.go
@@ -27,7 +27,7 @@ func getUsername(id int) {
 	service := "service-name"
 
 	policy := circuitbreaker.New(service)
-	policy.ThresholdErrors = 2
+	policy.ThresholdErrors = 1
 	policy.ResetTimeout = time.Millisecond * 500
 	policy.Errors = []error{errServiceUnavailable}
 	policy.Policy = timeout.Policy{

--- a/example/fallback/policy/main.go
+++ b/example/fallback/policy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,8 @@ func main() {
 	getUsername(1)
 	fmt.Printf("\n--------------------------------\n\n")
 	getUsername(2)
+	fmt.Printf("\n--------------------------------\n\n")
+	getUsername(3)
 }
 
 func getUsername(id int) {
@@ -21,10 +24,15 @@ func getUsername(id int) {
 	service := "service-name"
 
 	policy := fallback.New(service)
-	policy.Errors = []error{errUserNotFound} // Comment this line to get a panic error.
+	policy.Errors = []error{errUserNotFound, timeout.ErrExecutionTimedOut} // Comment this line to get a panic error.
 	policy.FallBackHandler = func(err error) {
-		fmt.Println("...")
-		userName = "New user"
+		if errors.Is(err, errUserNotFound) {
+			userName = "New user"
+		} else if errors.Is(err, timeout.ErrExecutionTimedOut) {
+			userName = "Unknown"
+		} else {
+			fmt.Println("Error:", err)
+		}
 	}
 
 	policy.Policy = timeout.Policy{
@@ -58,6 +66,9 @@ func getUsername(id int) {
 func fetchUserName(id int) string {
 	if id == 1 {
 		return "resiliencia"
+	} else if id == 2 {
+		time.Sleep(time.Millisecond * 250)
+		return "???"
 	}
 
 	return ""

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -80,6 +80,7 @@ func (p Policy) Run(metric core.Metric) error {
 	}
 
 	err := execute(p, metric)
+	err = pickError(err, metric)
 
 	if p.AfterFallBack != nil {
 		p.AfterFallBack(p, err)
@@ -96,8 +97,6 @@ func (p Policy) Run(metric core.Metric) error {
 
 	if err != nil {
 		p.FallBackHandler(err)
-	} else if !metric.Success() {
-		p.FallBackHandler(metric.MetricError())
 	}
 	metric[reflect.TypeOf(m).String()] = m
 
@@ -137,6 +136,14 @@ func validate(p Policy) error {
 	default:
 		return nil
 	}
+}
+
+func pickError(err error, metric core.MetricRecorder) error {
+	if err != nil {
+		return err
+	}
+
+	return metric.MetricError()
 }
 
 // ServiceID returns the service id registered to the policy binded to this metric.

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -153,3 +153,8 @@ func (m Metric) PolicyDuration() time.Duration {
 func (m Metric) Success() bool {
 	return (m.Status == 0) && (m.Error == nil)
 }
+
+// MetricError returns the error that a command supplier or a wrapped policy raised.
+func (m Metric) MetricError() error {
+	return m.Error
+}

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -86,7 +86,7 @@ func (p Policy) Run(metric core.Metric) error {
 	}
 	m.FinishedAt = time.Now()
 
-	if err != nil && !handledError(p, err) {
+	if !handledError(p, err) || !handledError(p, metric.MetricError()) {
 		m.Status = 1
 		m.Error = ErrUnhandledError
 		metric[reflect.TypeOf(m).String()] = m
@@ -96,6 +96,8 @@ func (p Policy) Run(metric core.Metric) error {
 
 	if err != nil {
 		p.FallBackHandler(err)
+	} else if !metric.Success() {
+		p.FallBackHandler(metric.MetricError())
 	}
 	metric[reflect.TypeOf(m).String()] = m
 

--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -87,7 +87,7 @@ func (p Policy) Run(metric core.Metric) error {
 	}
 	m.FinishedAt = time.Now()
 
-	if !handledError(p, err) || !handledError(p, metric.MetricError()) {
+	if !handledError(p, err) {
 		m.Status = 1
 		m.Error = ErrUnhandledError
 		metric[reflect.TypeOf(m).String()] = m

--- a/fallback/fallback_test.go
+++ b/fallback/fallback_test.go
@@ -241,13 +241,67 @@ func TestRunPolicyUnhandledError(t *testing.T) {
 	assert.False(t, fallbackMetric.Success())
 }
 
-func TestRunPolicyHandledError(t *testing.T) {
+func TestRunPolicyHandledErrorPolicyError(t *testing.T) {
 	fallbackCalled := false
 	errTest1 := errors.New("error test 1")
 	errTest2 := errors.New("error test 2")
 
 	policy := new(mockPolicy)
 	policy.On("Run").Return(errTest2)
+	mockMetric := Metric{
+		ID:         "dummy-service",
+		Status:     1,
+		StartedAt:  time.Now().Add(time.Millisecond * -150),
+		FinishedAt: time.Now(),
+		Error:      errTest2,
+	}
+
+	fallbackPolicy := fallback.New("service-id")
+	fallbackPolicy.Errors = []error{errTest1, errTest2}
+	fallbackPolicy.FallBackHandler = func(err error) {
+		fallbackCalled = true
+	}
+	fallbackPolicy.BeforeFallBack = func(p fallback.Policy) {}
+	fallbackPolicy.AfterFallBack = func(p fallback.Policy, err error) {}
+	fallbackPolicy.Policy = policy
+
+	metric := core.NewMetric()
+	metric[reflect.TypeOf(mockMetric).String()] = mockMetric
+	err := fallbackPolicy.Run(metric)
+
+	r := metric[reflect.TypeOf(Metric{}).String()]
+	childMetric, _ := r.(Metric)
+
+	assert.Nil(t, err)
+	assert.True(t, fallbackCalled)
+
+	assert.Equal(t, "dummy-service", childMetric.ID)
+	assert.Equal(t, 1, childMetric.Status)
+	assert.Less(t, childMetric.StartedAt, childMetric.FinishedAt)
+	assert.ErrorIs(t, childMetric.Error, errTest2)
+	assert.Equal(t, "dummy-service", childMetric.ServiceID())
+	assert.Greater(t, childMetric.PolicyDuration(), time.Nanosecond*100)
+	assert.False(t, childMetric.Success())
+
+	r = metric[reflect.TypeOf(fallback.Metric{}).String()]
+	fallbackMetric, _ := r.(fallback.Metric)
+
+	assert.Equal(t, "service-id", fallbackMetric.ID)
+	assert.Equal(t, 0, fallbackMetric.Status)
+	assert.Less(t, fallbackMetric.StartedAt, fallbackMetric.FinishedAt)
+	assert.Nil(t, fallbackMetric.Error)
+	assert.Equal(t, "service-id", fallbackMetric.ServiceID())
+	assert.Greater(t, fallbackMetric.PolicyDuration(), time.Nanosecond*100)
+	assert.True(t, fallbackMetric.Success())
+}
+
+func TestRunPolicyHandledErrorMetricError(t *testing.T) {
+	fallbackCalled := false
+	errTest1 := errors.New("error test 1")
+	errTest2 := errors.New("error test 2")
+
+	policy := new(mockPolicy)
+	policy.On("Run").Return(nil)
 	mockMetric := Metric{
 		ID:         "dummy-service",
 		Status:     1,

--- a/fallback/fallback_test.go
+++ b/fallback/fallback_test.go
@@ -49,6 +49,10 @@ func (m Metric) Success() bool {
 	return m.Status == 0
 }
 
+func (m Metric) MetricError() error {
+	return m.Error
+}
+
 func TestPolicyImplementsPolicySupplier(t *testing.T) {
 	p := fallback.New("service-id")
 	i := reflect.TypeOf((*core.PolicySupplier)(nil)).Elem()
@@ -113,7 +117,7 @@ func TestRunCommandNoFallback(t *testing.T) {
 	assert.Equal(t, "service-id", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Nil(t, m.Error)
+	assert.Nil(t, m.MetricError())
 	assert.Equal(t, "service-id", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
@@ -144,7 +148,7 @@ func TestRunCommandHandleError(t *testing.T) {
 	assert.Equal(t, "service-id", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Nil(t, m.Error)
+	assert.Nil(t, m.MetricError())
 	assert.Equal(t, "service-id", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
@@ -176,7 +180,7 @@ func TestRunCommandUnhandledError(t *testing.T) {
 	assert.Equal(t, "service-id", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, fallback.ErrUnhandledError)
+	assert.ErrorIs(t, m.MetricError(), fallback.ErrUnhandledError)
 	assert.Equal(t, "service-id", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -158,7 +158,7 @@ func (p Policy) Run(metric core.Metric) error {
 			p.AfterTry(p, turn, err)
 		}
 
-		if !handledError(p, err) || !handledError(p, metric.MetricError()) {
+		if !handledError(p, err) {
 			m.Status = 1
 			m.Error = ErrUnhandledError
 			metric[reflect.TypeOf(m).String()] = m

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -232,6 +232,11 @@ func (m Metric) Success() bool {
 	return (m.Status == 0) && (m.Error == nil)
 }
 
+// MetricError returns the error that a command supplier or a wrapped policy raised.
+func (m Metric) MetricError() error {
+	return m.Error
+}
+
 func handledError(p Policy, err error) bool {
 	return core.ErrorInErrors(p.Errors, err)
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -404,7 +404,6 @@ func TestRunPolicyMaxTriesExceeded(t *testing.T) {
 	mockMetric := Metric{
 		ID:         "dummy-service",
 		Status:     1,
-		Error:      fmt.Errorf("any"),
 		StartedAt:  time.Now().Add(time.Millisecond * -150),
 		FinishedAt: time.Now(),
 	}
@@ -434,7 +433,7 @@ func TestRunPolicyMaxTriesExceeded(t *testing.T) {
 	assert.Equal(t, "dummy-service", childMetric.ID)
 	assert.Equal(t, 1, childMetric.Status)
 	assert.Less(t, childMetric.StartedAt, childMetric.FinishedAt)
-	assert.NotNil(t, childMetric.MetricError())
+	assert.Nil(t, childMetric.MetricError())
 	assert.Equal(t, "dummy-service", childMetric.ServiceID())
 	assert.Greater(t, childMetric.PolicyDuration(), time.Millisecond*150)
 	assert.Greater(t, time.Millisecond*151, childMetric.PolicyDuration())

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -2,6 +2,7 @@ package retry_test
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -47,6 +48,10 @@ func (m Metric) PolicyDuration() time.Duration {
 
 func (m Metric) Success() bool {
 	return m.Status == 0
+}
+
+func (m Metric) MetricError() error {
+	return m.Error
 }
 
 func TestPolicyImplementsPolicySupplier(t *testing.T) {
@@ -128,6 +133,7 @@ func TestRunCommandMaxTriesExceeded(t *testing.T) {
 	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
+	assert.NotNil(t, m.MetricError())
 
 	for _, exec := range m.Executions {
 		assert.ErrorIs(t, errTest, exec.Error)
@@ -179,6 +185,7 @@ func TestRunCommandHandledErrors(t *testing.T) {
 	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
+	assert.Nil(t, m.MetricError())
 
 	assert.ErrorIs(t, errTest1, m.Executions[0].Error)
 	assert.ErrorIs(t, errTest2, m.Executions[1].Error)
@@ -233,6 +240,7 @@ func TestRunCommandUnhandledError(t *testing.T) {
 	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
+	assert.NotNil(t, m.MetricError())
 
 	assert.ErrorIs(t, errTest1, m.Executions[0].Error)
 	assert.ErrorIs(t, errTest2, m.Executions[1].Error)
@@ -269,6 +277,7 @@ func TestRunCommand(t *testing.T) {
 	assert.Equal(t, "postForm", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*50)
 	assert.True(t, m.Success())
+	assert.Nil(t, m.MetricError())
 }
 
 func TestRunPolicy(t *testing.T) {
@@ -312,6 +321,7 @@ func TestRunPolicy(t *testing.T) {
 	assert.Greater(t, childMetric.PolicyDuration(), time.Millisecond*150)
 	assert.Greater(t, time.Millisecond*151, childMetric.PolicyDuration())
 	assert.True(t, childMetric.Success())
+	assert.Nil(t, childMetric.MetricError())
 
 	r = metric[reflect.TypeOf(retry.Metric{}).String()]
 	retryMetric, _ := r.(retry.Metric)
@@ -324,6 +334,7 @@ func TestRunPolicy(t *testing.T) {
 	assert.Nil(t, retryMetric.Executions[0].Error)
 	assert.Equal(t, "remote-service", retryMetric.ServiceID())
 	assert.True(t, retryMetric.Success())
+	assert.Nil(t, retryMetric.MetricError())
 }
 
 func TestRunPolicyUnhandledError(t *testing.T) {
@@ -335,6 +346,7 @@ func TestRunPolicyUnhandledError(t *testing.T) {
 	mockMetric := Metric{
 		ID:         "dummy-service",
 		Status:     1,
+		Error:      fmt.Errorf("any"),
 		StartedAt:  time.Now().Add(time.Millisecond * -150),
 		FinishedAt: time.Now(),
 	}
@@ -363,7 +375,7 @@ func TestRunPolicyUnhandledError(t *testing.T) {
 	assert.Equal(t, "dummy-service", childMetric.ID)
 	assert.Equal(t, 1, childMetric.Status)
 	assert.Less(t, childMetric.StartedAt, childMetric.FinishedAt)
-	assert.Nil(t, childMetric.Error)
+	assert.NotNil(t, childMetric.MetricError())
 	assert.Equal(t, "dummy-service", childMetric.ServiceID())
 	assert.Greater(t, childMetric.PolicyDuration(), time.Millisecond*150)
 	assert.Greater(t, time.Millisecond*151, childMetric.PolicyDuration())
@@ -380,6 +392,7 @@ func TestRunPolicyUnhandledError(t *testing.T) {
 	assert.ErrorIs(t, retryMetric.Executions[0].Error, errTest)
 	assert.Equal(t, "remote-service", retryMetric.ServiceID())
 	assert.False(t, retryMetric.Success())
+	assert.NotNil(t, retryMetric.MetricError())
 }
 
 func TestRunPolicyMaxTriesExceeded(t *testing.T) {
@@ -391,6 +404,7 @@ func TestRunPolicyMaxTriesExceeded(t *testing.T) {
 	mockMetric := Metric{
 		ID:         "dummy-service",
 		Status:     1,
+		Error:      fmt.Errorf("any"),
 		StartedAt:  time.Now().Add(time.Millisecond * -150),
 		FinishedAt: time.Now(),
 	}
@@ -420,7 +434,7 @@ func TestRunPolicyMaxTriesExceeded(t *testing.T) {
 	assert.Equal(t, "dummy-service", childMetric.ID)
 	assert.Equal(t, 1, childMetric.Status)
 	assert.Less(t, childMetric.StartedAt, childMetric.FinishedAt)
-	assert.Nil(t, childMetric.Error)
+	assert.NotNil(t, childMetric.MetricError())
 	assert.Equal(t, "dummy-service", childMetric.ServiceID())
 	assert.Greater(t, childMetric.PolicyDuration(), time.Millisecond*150)
 	assert.Greater(t, time.Millisecond*151, childMetric.PolicyDuration())
@@ -439,6 +453,7 @@ func TestRunPolicyMaxTriesExceeded(t *testing.T) {
 	}
 	assert.Equal(t, "remote-service", retryMetric.ServiceID())
 	assert.False(t, retryMetric.Success())
+	assert.NotNil(t, retryMetric.MetricError())
 }
 
 func TestWithCommand(t *testing.T) {

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -167,6 +167,11 @@ func (m Metric) Success() bool {
 	return (m.Status == 0) && (m.Error == nil)
 }
 
+// MetricError returns the error that a command supplier or a wrapped policy raised.
+func (m Metric) MetricError() error {
+	return m.Error
+}
+
 func validate(p Policy) error {
 	switch {
 	case p.Timeout < MinTimeout:

--- a/timeout/timeout_test.go
+++ b/timeout/timeout_test.go
@@ -50,6 +50,10 @@ func (m Metric) Success() bool {
 	return m.Status == 0
 }
 
+func (m Metric) MetricError() error {
+	return m.Error
+}
+
 func TestPolicyImplementsPolicySupplier(t *testing.T) {
 	p := timeout.New("remote-service")
 	i := reflect.TypeOf((*core.PolicySupplier)(nil)).Elem()
@@ -116,7 +120,7 @@ func TestRunCommand(t *testing.T) {
 	assert.Equal(t, "remote-service", m.ID)
 	assert.Equal(t, 0, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.Nil(t, m.Error)
+	assert.Nil(t, m.MetricError())
 	assert.Equal(t, "remote-service", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.True(t, m.Success())
@@ -140,7 +144,7 @@ func TestRunCommandWithUnknownError(t *testing.T) {
 	assert.Equal(t, "remote-service", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, m.Error, errTest)
+	assert.ErrorIs(t, m.MetricError(), errTest)
 	assert.Equal(t, "remote-service", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())
@@ -166,7 +170,7 @@ func TestRunCommandTimeout(t *testing.T) {
 	assert.Equal(t, "remote-service", m.ID)
 	assert.Equal(t, 1, m.Status)
 	assert.Less(t, m.StartedAt, m.FinishedAt)
-	assert.ErrorIs(t, timeout.ErrExecutionTimedOut, m.Error)
+	assert.ErrorIs(t, timeout.ErrExecutionTimedOut, m.MetricError())
 	assert.Equal(t, "remote-service", m.ServiceID())
 	assert.Greater(t, m.PolicyDuration(), time.Nanosecond*100)
 	assert.False(t, m.Success())


### PR DESCRIPTION
Fixes bugs in circuit breaker, retry and fallback that occurred when a policy did not return error although a metric with error. In those cases, errors were not handled properly. Closes #24, #25, #26.